### PR TITLE
Add recipe show controller

### DIFF
--- a/controllers/base.rb
+++ b/controllers/base.rb
@@ -10,5 +10,9 @@ class Base < Sinatra::Base
   before do
     @app_name = APP_NAME
     @title = 'タイトル'
+
+    if session[:user_id]
+      @current_user = User.find(session[:user_id])
+    end
   end
 end

--- a/controllers/recipe_controller.rb
+++ b/controllers/recipe_controller.rb
@@ -12,7 +12,7 @@ class RecipesController < Base
     #ジャンル選択画面で選ばれた食材名・ジャンルをURL末尾に設定する
     food = UserFood.where(user_id: session[:user_id]).order(limit_date: :desc).limit(1)
     if params[:genre].blank?
-      url = URI.encode "https://cookpad.com/search/#{food[0].name}" 
+      url = URI.encode "https://cookpad.com/search/#{food[0].name}"
     else
       url = URI.encode 'https://cookpad.com/search/'+ params[:genre] + '%E3%80%80' + food[0].name
     end

--- a/controllers/recipe_controller.rb
+++ b/controllers/recipe_controller.rb
@@ -44,14 +44,11 @@ class RecipesController < Base
       redirect '/recipe' and return
     end
 
-    charset = nil
     # TODO: ネットワークエラーがおきたらどうする？
-    html = open("https://cookpad.com#{recipe_path}") do |page|
-      charset = page.charset
-      page.read
+    doc = open("https://cookpad.com#{recipe_path}") do |page|
+      Nokogiri::HTML.parse(page.read, nil, page.charset)
     end
 
-    doc = Nokogiri::HTML.parse(html, nil, charset)
     @recipe_title = parse_recipe_title_from(doc)
     @recipe_image = parse_recipe_image_from(doc)
 

--- a/controllers/recipe_controller.rb
+++ b/controllers/recipe_controller.rb
@@ -53,25 +53,38 @@ class RecipesController < Base
 
     doc = Nokogiri::HTML.parse(html, nil, charset)
     @recipe_title = doc.xpath('//*[@id="recipe-title"]/h1').first.text
-    @recipe_image = doc.xpath('//*[@id="main-photo"]/img').first.attribute("src").value
+    @recipe_image = doc.xpath('//*[@id="main-photo"]/img').first.attribute('src').value
 
     # 材料一覧
     @ingredients = []
-    doc.xpath('//*[@id="ingredients_list"]/div').each do |material_node|
+    doc.xpath('//*[@id="ingredients_list"]/div').each do |ingredient_node|
       # 材料名ではなくカテゴリ名が表示されている場合に対応
-      category = material_node.xpath('.//div[@class="ingredient_category"]')
+      category = ingredient_node.xpath('.//div[@class="ingredient_category"]')
       unless category.empty?
         @ingredients << category.text
         next
       end
 
       @ingredients << {
-        name: material_node.xpath('.//div[@class="ingredient_name"]/span').text,
-        amount: material_node.xpath('.//div[@class="ingredient_quantity amount"]').text,
+        name: ingredient_node.xpath('.//div[@class="ingredient_name"]/span').text,
+        amount: ingredient_node.xpath('.//div[@class="ingredient_quantity amount"]').text,
       }
     end
 
     # TODO: 調理手順
+    @steps = []
+    doc.xpath('//*[@id="steps"]/div[contains(@class, "step")]/dl/dd').each do |step_node|
+      step = {
+        text: step_node.xpath('.//p').text
+      }
+
+      img_node = step_node.xpath('.//div/div/img')
+      unless img_node.empty?
+        step[:photo_src] = img_node.attribute('src').value
+      end
+
+      @steps << step
+    end
 
     erb :'recipes/recipe_detail'
   end

--- a/controllers/recipe_controller.rb
+++ b/controllers/recipe_controller.rb
@@ -44,9 +44,13 @@ class RecipesController < Base
       redirect '/recipe' and return
     end
 
-    # TODO: ネットワークエラーがおきたらどうする？
-    doc = open("https://cookpad.com#{recipe_path}") do |page|
-      Nokogiri::HTML.parse(page.read, nil, page.charset)
+    doc = begin
+      open("https://cookpad.com#{recipe_path}") do |page|
+        Nokogiri::HTML.parse(page.read, nil, page.charset)
+      end
+    rescue OpenURI::HTTPError
+      # TODO: エラーメッセージを動的に設定できる404ページを作成する
+      return [404, ['指定したレシピが見つかりませんでした。', '再度検索をお願いいたします。']]
     end
 
     @recipe_title = parse_recipe_title_from(doc)

--- a/controllers/sessions_controller.rb
+++ b/controllers/sessions_controller.rb
@@ -26,6 +26,7 @@ class SessionsController < Base
 
   get '/logout' do
     session[:user_id] = nil
+    @current_user = nil
 
     redirect '/'
   end

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -34,10 +34,32 @@
             </div>
           </li>
         </ul>
-        <form class="form-inline my-2 my-lg-0">
-          <input type="search" class="form-control mr-sm-2" placeholder="検索..." aria-label="検索...">
-          <button type="submit" class="btn btn-outline-success my-2 my-sm-0">検索</button>
-        </form>
+
+        <!-- Right Side Of Navbar -->
+        <ul class="navbar-nav ml-auto">
+          <% if @current_user %>
+            <li class="nav-item dropdown">
+              <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
+                <span class="user-font"><%= @current_user.name %></span> <span class="caret"></span>
+              </a>
+
+              <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+                <a class="dropdown-item" href="#">メニュー</a>
+
+                <!-- Logout form -->
+                <a class="dropdown-item" href="/auth/logout">ログアウト</a>
+              </div>
+            </li>
+          <% else %>
+            <li class="nav-item">
+              <a class="nav-link" href="/auth/login">ログイン</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/signup">登録</a>
+            </li>
+          <% end %>
+        </ul>
+
       </div><!-- /.navbar-collapse -->
     </nav>
 

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -22,6 +22,9 @@
           <li class="nav-item active">
             <a class="nav-link" href="#">ホーム <span class="sr-only">(現位置)</span></a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/recipe">仮レシピ出力</a>
+          </li>
           <li class="nav-item dropdown">
             <a href="#" class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               ドロップダウン

--- a/views/recipes/recipe_detail.erb
+++ b/views/recipes/recipe_detail.erb
@@ -1,0 +1,11 @@
+<h1><%= @recipe_title %></h1>
+<img src="<%= @recipe_image %>" />
+
+<% @ingredients.each do |ingredient| %>
+  <% if ingredient.kind_of?(Hash) %>
+    <p><%= ingredient[:name] %> - <%= ingredient[:amount] %></p>
+  <% else %>
+    <%# 「■食材A」のように表示される %>
+    <p><%= ingredient%></p>
+  <% end %>
+<% end %>

--- a/views/recipes/recipe_detail.erb
+++ b/views/recipes/recipe_detail.erb
@@ -1,11 +1,21 @@
 <h1><%= @recipe_title %></h1>
 <img src="<%= @recipe_image %>" />
 
+<%# 材料一覧 %>
 <% @ingredients.each do |ingredient| %>
   <% if ingredient.kind_of?(Hash) %>
     <p><%= ingredient[:name] %> - <%= ingredient[:amount] %></p>
   <% else %>
-    <%# 「■食材A」のように表示される %>
+    <%# 材料がカテゴリ分けされている時、ここでは「■食材A」のように表示される %>
     <p><%= ingredient%></p>
   <% end %>
+<% end %>
+
+<%# 調理手順 %>
+<% @steps.each do |step| %>
+  <% if step[:photo_src] %>
+    <img src="<%= step[:photo_src] %>" />
+  <% end %>
+
+  <p><%= step[:text] %></p>
 <% end %>

--- a/views/recipes/search_results.erb
+++ b/views/recipes/search_results.erb
@@ -1,6 +1,9 @@
 <% @recipes.each do |item| %>
-  <p><%= item[:recipe_title] %></p>
-  <p><%= item[:recipe_link] %></p>
+  <p>
+    <a href="<%= "/recipe/show?recipe_path=#{item[:recipe_link]}" %>">
+      <%= item[:recipe_title] %>
+    </a>
+  </p>
   <img src="<%= item[:thumbnail] %>" />
   <br>
 <% end %>


### PR DESCRIPTION
## やったこと
- ログインしている場合、`@current_user`に自身のユーザーモデルが格納されるようにした
- レシピ詳細をクックパッドからスクレイプし、表示するコントローラを実装
- ログイン状態によってヘッダ部分が変更されるようにした
- レシピ出力ページへの仮リンクをヘッダーにつけた(作業用のやつなのでホーム画面ができたら消す)
- レシピ検索画面からレシピ名をクリックするとレシピ詳細画面に飛ぶようにリンクをつけた

## とりあえず要素だけ全部表示させた画面
<img width="1334" alt="スクリーンショット 2019-05-21 23 30 50" src="https://user-images.githubusercontent.com/22770924/58104886-809bc280-7c20-11e9-9836-8e494291aa54.png">